### PR TITLE
Release/v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,27 @@ import 'react-treeselectjs/dist/react-treeselectjs.css'
 
 Import treeselectjs (UMD)
 ```
-<script src="https://cdn.jsdelivr.net/npm/react-treeselectjs@0.5.1/dist/react-treeselectjs.umd.js"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/react-treeselectjs@0.5.1/dist/react-treeselectjs.css" />
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  
+  <script src="https://cdn.jsdelivr.net/npm/treeselectjs@0.12.0/dist/treeselectjs.umd.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/react-treeselectjs@0.6.0/dist/react-treeselectjs.umd.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/react-treeselectjs@0.6.0/dist/react-treeselectjs.css" />
+</head>
+<body>
+  <div id="root"></div>
+  
+  <script type="text/babel">
+
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<ReactTreeselect />);
+  </script>
+</body>
+</html>
 ```
 
 All Available Imports
@@ -120,7 +139,7 @@ export default App
 Name  | Type (default) | Description
 ------------- | ------------- | -------------
 **value**  | Array[String \| Number] ([]) | An array of `value` from `options` prop. This value will be selected on load of the treeselect. The `value` changes if you check/uncheck checkboxes or remove tags from the input.
-**options**  | Array[Object] ([]) | It is an array of objects ```{name: String, value: String, disabled?: Boolean, htmlAttr?: object, children: [] }```, where children are the same array of objects. Do not use duplicated `value` field. But you can use duplicated names. [Read more](#option-description).
+**options**  | Array[Object] ([]) | It is an array of objects ```{name: String, value: String \| Number, disabled?: Boolean, htmlAttr?: object, children: [] }```, where children are the same array of objects. Do not use duplicated `value` field. But you can use duplicated names. [Read more](#option-description).
 **disabled** | Boolean (false) | List will be disabled.
 **id** | String ('') | id attribute for the accessibility.
 **ariaLabel** | String ('') | ariaLabel attribute for the accessibility.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-treeselectjs",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-treeselectjs",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "treeselectjs": "0.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-treeselectjs",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Treeselect React Component",
   "main": "./dist/react-treeselectjs.umd.js",
   "module": "./dist/react-treeselectjs.mjs",

--- a/src/Treeselect.tsx
+++ b/src/Treeselect.tsx
@@ -93,6 +93,9 @@ const Treeselect = (props: PropsWithChildren<TreeselectProps>) => {
       if (isValueChanged) {
         treeselect.current.options = props.options ?? []
         treeselect.current.mount()
+
+        // Update value if options changed
+        treeselect.current.updateValue(props.value)
       }
     }
   }, [props.options])

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,11 +23,17 @@ export default defineConfig({
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
-          treeselectjs: 'TreeselectJS',
-          'react-treeselectjs': 'Treeselect'
+          treeselectjs: 'Treeselect',
+          'react-treeselectjs': 'ReactTreeselect'
         }
       }
     }
   },
-  plugins: [react(), dts()]
+  plugins: [
+    react({
+      // Using the classic runtime to avoid JSX in the bundle. This needs to be tested over time.
+      jsxRuntime: 'classic'
+    }),
+    dts()
+  ]
 })


### PR DESCRIPTION
- Fix: Ensure the value is updated when the options are changed, addressing cases where updates were previously ignored.
- Update: Rename the global variable in the CDN configuration from Treeselect to ReactTreeselect.
- Documentation: Update the CDN usage instructions in the README to align with the renamed global variable.
- Apply jsxRuntaime classic to avoid JSX in the final bundle.
